### PR TITLE
Fix TypeError on COI default alpha value

### DIFF
--- a/lib/scaleogram/cws.py
+++ b/lib/scaleogram/cws.py
@@ -29,7 +29,7 @@ CBAR_DEFAULTS = {
 }
 
 COI_DEFAULTS = {
-        'alpha':'0.5',
+        'alpha':0.5,
         'hatch':'/',
 }
 


### PR DESCRIPTION
The default alpha value for the cone of influence is a string, '0.5'. This causes the error:

TypeError: alpha must be a float or None

This tiny fix changes the default from string to float and fixes the error.