### PR TITLE
Small change to ensure compatibility with newer matplotlib version

### DIFF
--- a/lib/scaleogram/cws.py
+++ b/lib/scaleogram/cws.py
@@ -29,7 +29,7 @@ CBAR_DEFAULTS = {
 }
 
 COI_DEFAULTS = {
-        'alpha':'0.5',
+        'alpha':0.5,
         'hatch':'/',
 }
 


### PR DESCRIPTION
Some versions of matplotlib (at least version 3.2.2) seems to expect alpha to be either none or a float. This change suggest having alpha as a float instead of as a string, so that matplotlib does not fail. 