### PR TITLE
Change COI_DEFAULTS['alpha']=0.5 instead of '0.5'

### DIFF
--- a/lib/scaleogram/cws.py
+++ b/lib/scaleogram/cws.py
@@ -29,7 +29,7 @@ CBAR_DEFAULTS = {
 }
 
 COI_DEFAULTS = {
-        'alpha':'0.5',
+        'alpha':0.5,
         'hatch':'/',
 }
 


### PR DESCRIPTION
Hi, I'm using the package on Colab and it's extremely useful, so thanks :))

The problem is that I have to re-install it from pip every time I reset the runtime, and then find the package, change the value to 0.5 and run it again to avoid the "alpha must be int or float" error. Figured it might be a good idea to simply change the source.